### PR TITLE
add dockerfile and fix dashboard typo

### DIFF
--- a/dashboards/Veeam_Enterprise_Manager.json
+++ b/dashboards/Veeam_Enterprise_Manager.json
@@ -3570,7 +3570,7 @@
             "backupserver": {
               "selected": true,
               "text": "",
-              "value": "",
+              "value": ""
             }
           },
           "targets": [
@@ -3811,10 +3811,8 @@
         "current": {
           "selected": true,
           "tags": [],
-          "text": [ 
-          ],
-          "value": [
-          ]
+          "text": [],
+          "value": []
         },
         "datasource": null,
         "definition": "label_values(veeam_em_backup_servers_config, name)",

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim-buster
+
+WORKDIR /app
+
+COPY pip_requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+COPY veeam_exporter_src/. .
+
+EXPOSE 9247/tcp
+
+ENTRYPOINT [ "python3", "t.py"]

--- a/veeam_exporter_src/veeam_exporter/conf/config.yml
+++ b/veeam_exporter_src/veeam_exporter/conf/config.yml
@@ -1,10 +1,9 @@
-
-veeams: 
+veeams:
   - host: host.domaine
     port: 9398
-    user: 'user'
-    password: 'password'
-#      protocol: https
+    user: "user"
+    password: "password"
+    #      protocol: https
     verify_ssl: false
     timeout: 20
 #    keep_session: true # default
@@ -21,7 +20,6 @@ weblisten:
 
 logger:
   level: info
-  facility: syslog
+  facility: stdout
 
 metrics_file: "conf/metrics/*_metrics.yml"
-


### PR DESCRIPTION
Hey

Thanks for creating the exporter.

I've added a dockerfile to make it possible to run this in Docker/Kubernetes and fixed a typo in the dashboard.

I did notice that even with the log output set to `stdout` there is not log when running it in the container - perhaps it's something to do with the logging library as this was fine when ran on WSL

Would be nice if you could publish an image for this project automatically as the maintainer; however, in the meantime, I've published a build as `mateuszd/veeam-exporter` if anyone wants to try.

Thanks!